### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/COLORECTAL CANCER PREDICTION/CODE/application.py
+++ b/COLORECTAL CANCER PREDICTION/CODE/application.py
@@ -5,6 +5,9 @@ import numpy as np
 
 app = Flask(__name__)
 
+import logging
+logging.basicConfig(level=logging.ERROR, format='%(asctime)s - %(levelname)s - %(message)s')
+
 model_path = "artifacts/models/model.pkl"
 scaler_path = "artifacts/processed/scaler.pkl"
 
@@ -33,7 +36,9 @@ def predict():
         return render_template('index.html' , prediction=prediction)
     
     except Exception as e:
-        return str(e)
+        import logging
+        logging.error(f"An error occurred: {str(e)}")
+        return "An internal error has occurred. Please try again later."
     
 if __name__=="__main__":
     app.run(debug=True , host="0.0.0.0" , port=5000)


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/UDEMY-MLOPS-COURSE/security/code-scanning/2](https://github.com/venkateshpabbati/UDEMY-MLOPS-COURSE/security/code-scanning/2)

To fix the issue, the application should log the exception details on the server and return a generic error message to the user. This ensures that sensitive information is not exposed while still allowing developers to debug the issue using server-side logs.

**Steps to fix:**
1. Replace `str(e)` with a generic error message for the user, such as `"An internal error has occurred. Please try again later."`.
2. Log the exception details (`str(e)`) on the server using a logging library like Python's built-in `logging` module.
3. Ensure the logging setup is configured to write logs to a file or console for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
