### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/USER SURVIVAL PREDICTION/Code/application.py
+++ b/USER SURVIVAL PREDICTION/Code/application.py
@@ -88,7 +88,8 @@ def predict():
         return render_template('index.html' , prediction_text = f"The predictions is : {result}")
     
     except Exception as e:
-        return jsonify({'error' : str(e)})
+        logger.error("Exception in /predict: %s", str(e), exc_info=True)
+        return jsonify({'error': 'An internal error has occurred.'})
     
 @app.route('/metrics')
 def metrics():


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/UDEMY-MLOPS-COURSE/security/code-scanning/1](https://github.com/venkateshpabbati/UDEMY-MLOPS-COURSE/security/code-scanning/1)

To fix the problem, we should avoid returning the raw exception message to the user. Instead, we should log the exception details on the server for debugging purposes and return a generic error message to the user. This can be done by replacing `return jsonify({'error' : str(e)})` with a call to the logger (already available as `logger`) to log the exception, and returning a generic error message such as `return jsonify({'error': 'An internal error has occurred.'})`. The change should be made in the `/predict` route handler, specifically in the `except` block. No new imports are needed, as the logger is already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
